### PR TITLE
DSN, Configuration and PHP error handling options

### DIFF
--- a/src/app/code/community/AMG/Sentry/Model/Client.php
+++ b/src/app/code/community/AMG/Sentry/Model/Client.php
@@ -1,14 +1,19 @@
 <?php
 
 $ravenDir = Mage::getBaseDir() . DS . 'lib' . DS . 'Raven';
-require_once($ravenDir . DS . 'Client.php');
-require_once($ravenDir . DS . 'Compat.php');
-require_once($ravenDir . DS . 'ErrorHandler.php');
-require_once($ravenDir . DS . 'Stacktrace.php');
+require_once($ravenDir . DS . 'Autoloader.php');
+Raven_Autoloader::register();
+//require_once($ravenDir . DS . 'Compat.php');
+//require_once($ravenDir . DS . 'ErrorHandler.php');
+//require_once($ravenDir . DS . 'Stacktrace.php');
 
 class AMG_Sentry_Model_Client extends Raven_Client {
 
-	protected $_logger = null;
+	static protected $_logger = null;
+
+    function __construct() {
+        parent::__construct(Mage::getStoreConfig('dev/amg-sentry/dsn'));
+    }
 
 	/**
 	* Send a message to Sentry.

--- a/src/app/code/community/AMG/Sentry/Model/Observer.php
+++ b/src/app/code/community/AMG/Sentry/Model/Observer.php
@@ -7,10 +7,16 @@ class AMG_Sentry_Model_Observer {
             require_once(dirname(__FILE__) . DS . '..' . DS . 'functions.php');
             Mage::app()->setErrorHandler('sentry_error_handler');
 
-            $error_handler = new Raven_ErrorHandler(Mage::getSingleton('amg-sentry/client'));
-            set_error_handler(array($error_handler, 'handleError'));
-            set_exception_handler(array($error_handler, 'handleException'));
+            $php_error_handler = new Raven_ErrorHandler(Mage::getSingleton('amg-sentry/client'));
+            if (Mage::getStoreConfigFlag('dev/amg-sentry/php-errors')) {
+                set_error_handler(array($php_error_handler, 'handleError'));
+            }
+
+            if (Mage::getStoreConfigFlag('dev/amg-sentry/php-exceptions')) {
+                set_exception_handler(array($php_error_handler, 'handleException'));
+            }
         }
     }
 
 }
+

--- a/src/app/code/community/AMG/Sentry/Model/Observer.php
+++ b/src/app/code/community/AMG/Sentry/Model/Observer.php
@@ -6,6 +6,10 @@ class AMG_Sentry_Model_Observer {
         if (Mage::getStoreConfigFlag('dev/amg-sentry/active')) {
             require_once(dirname(__FILE__) . DS . '..' . DS . 'functions.php');
             Mage::app()->setErrorHandler('sentry_error_handler');
+
+            $error_handler = new Raven_ErrorHandler(Mage::getSingleton('amg-sentry/client'));
+            set_error_handler(array($error_handler, 'handleError'));
+            set_exception_handler(array($error_handler, 'handleException'));
         }
     }
 

--- a/src/app/code/community/AMG/Sentry/etc/config.xml
+++ b/src/app/code/community/AMG/Sentry/etc/config.xml
@@ -46,6 +46,8 @@
 				<active>false</active>
 				<dsn>http://public:secret@sentry.example.com:9000/[PROJECT_ID]</dsn>
 				<logger>magento</logger>
+                <php-errors>false</php-errors>
+                <php-exceptions>false</php-exceptions>
 			</amg-sentry>
 		</dev>
 	</default>

--- a/src/app/code/community/AMG/Sentry/etc/system.xml
+++ b/src/app/code/community/AMG/Sentry/etc/system.xml
@@ -52,6 +52,24 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </logger>
+                        <php-errors>
+                            <label>Enable PHP errors logging?</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>40</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </php-errors>
+                        <php-exceptions>
+                            <label>Enable PHP exceptions logging?</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>50</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </php-exceptions>
 					</fields>
 				</amg-sentry>
 			</groups>

--- a/src/lib/Raven/Autoloader.php
+++ b/src/lib/Raven/Autoloader.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Autoloads Raven classes.
+ *
+ * @package raven
+ */
+class Raven_Autoloader
+{
+    /**
+     * Registers Raven_Autoloader as an SPL autoloader.
+     */
+    static public function register()
+    {
+        ini_set('unserialize_callback_func', 'spl_autoload_call');
+        spl_autoload_register(array(new self, 'autoload'));
+    }
+
+    /**
+     * Handles autoloading of classes.
+     *
+     * @param  string  $class  A class name.
+     *
+     * @return boolean Returns true if the class has been loaded
+     */
+    static public function autoload($class)
+    {
+        if (0 !== strpos($class, 'Raven')) {
+            return;
+        }
+
+        if (is_file($file = dirname(__FILE__).'/../'.str_replace(array('_', "\0"), array('/', ''), $class).'.php')) {
+            require $file;
+        }
+    }
+}

--- a/src/lib/Raven/Processor.php
+++ b/src/lib/Raven/Processor.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Base class for data processing.
+ *
+ * @package raven
+ */
+class Raven_Processor
+{
+    function __construct($client)
+    {
+        $this->client = $client;
+    }
+
+    /** 
+     * Process data and return updated message.
+     */
+    public function process($data)
+    {
+        return $data;
+    }
+}

--- a/src/lib/Raven/SanitizeDataProcessor.php
+++ b/src/lib/Raven/SanitizeDataProcessor.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Asterisk out passwords from password fields in frames, http,
+ * and basic extra data.
+ *
+ * @package raven
+ */
+class Raven_SanitizeDataProcessor extends Raven_Processor
+{
+    const MASK = '********';
+    const FIELDS_RE = '/(authorization|password|passwd|secret)/i';
+    const VALUES_RE = '/^\d{16}$/';
+
+    function apply($value, $fn, $key=null) {
+        if (is_array($value)) {
+            foreach ($value as $k=>$v) {
+                $value[$k] = $this->apply($v, $fn, $k);
+            }
+            return $value;
+        }
+        return call_user_func($fn, $key, $value);
+    }
+
+    function sanitize($key, $value)
+    {
+        if (empty($value)) {
+            return $value;
+        }
+
+        if (preg_match(self::VALUES_RE, $value)) {
+            return self::MASK;
+        }
+
+        if (preg_match(self::FIELDS_RE, $key)) {
+            return self::MASK;
+        }
+
+        return $value;
+    }
+
+    function process($data) {
+        return $this->apply($data, array($this, 'sanitize'));
+    }
+}


### PR DESCRIPTION
I've added:
- DSN setting from configuration (in constructor) - plugin didn't work without this,
- options for PHP error and exceptions handling (with stacktrace) - magento logger doesn't send this,
- new raven-php files from latest version.
