### PR TITLE
#2: sentry handler can now decide if it will ignore @ operator or not

### DIFF
--- a/src/app/code/community/AMG/Sentry/etc/config.xml
+++ b/src/app/code/community/AMG/Sentry/etc/config.xml
@@ -48,6 +48,7 @@
 				<logger>magento</logger>
                 <php-errors>false</php-errors>
                 <php-exceptions>false</php-exceptions>
+                <ignore-error-control-operator>true</ignore-error-control-operator>
 			</amg-sentry>
 		</dev>
 	</default>

--- a/src/app/code/community/AMG/Sentry/etc/system.xml
+++ b/src/app/code/community/AMG/Sentry/etc/system.xml
@@ -70,6 +70,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </php-exceptions>
+                        <ignore-error-control-operator>
+                            <label>Ignore PHP error control operator (@)?</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>50</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </ignore-error-control-operator>
 					</fields>
 				</amg-sentry>
 			</groups>

--- a/src/app/code/community/AMG/Sentry/functions.php
+++ b/src/app/code/community/AMG/Sentry/functions.php
@@ -9,5 +9,7 @@
  * @param integer $errline
  */
 function sentry_error_handler($errno, $errstr, $errfile, $errline){
-	Mage::getSingleton('amg-sentry/client')->sendMessage($errstr, sprintf('In %s on line %d', $errfile, $errline));
+    if(error_reporting() != 0 or Mage::getStoreConfigFlag('dev/amg-sentry/ignore-error-control-operator')){
+        Mage::getSingleton('amg-sentry/client')->sendMessage($errstr, sprintf('In %s on line %d', $errfile, $errline));
+    }
 }


### PR DESCRIPTION
right now the behaviour is to always ignore the @ (error control)
operator, this change allows the user of the extension to decided if it
will be the case in his installation or not. The default will be to
ignore the @ operator and always log errors to sentry.
